### PR TITLE
Add shebang to go.sh

### DIFF
--- a/src/starter_repo/contents/go.sh
+++ b/src/starter_repo/contents/go.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # silence script
 exec 3>&1 4>&2 1>/dev/null 2>&1
 


### PR DESCRIPTION
resolves #6 

I think that `bash` is the right choice here since
* almost every machine has bash (it is git _bash_ in windows, after all)
* this script is known to work in bash; new debian uses `dash` as `/bin/sh`, which isn't quite exactly compatible (at least for gpg agent forwarding)